### PR TITLE
Added functionality to delete and disable payment types.

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -2,7 +2,10 @@ from django.contrib.auth.models import User
 from django.core.validators import MinValueValidator
 from django.db import models
 
-
+options = (
+        (0, 'False'),
+        (1, 'True'),
+)
 # Create your models here.
 class Category(models.Model):
     """
@@ -59,7 +62,7 @@ class Product(models.Model):
     # Come back to the price field, in order to not allow negative numbers
     price = models.DecimalField(max_digits = 19, decimal_places = 2, validators = [MinValueValidator('0.0')])
     description = models.TextField(blank = True, null = True)
-    quantity = models.PositiveIntegerField() 
+    quantity = models.PositiveIntegerField()
     is_local = models.BooleanField(default=False)
     city = models.CharField(max_length = 255, blank = True, null = True)
     date = models.DateTimeField(auto_now_add=True, blank=True)
@@ -71,12 +74,10 @@ class PaymentType(models.Model):
     args: models.Model
     returns: N/A
     """
-    user = models.ForeignKey(
-        User,
-        on_delete = models.CASCADE,
-    )
+    user = models.ForeignKey(User)
     name = models.CharField(max_length = 255)
     account_number = models.IntegerField()
+    enabled = models.IntegerField(default=1, choices=options)
 
 class Order(models.Model):
     """
@@ -91,7 +92,6 @@ class Order(models.Model):
     )
     payment_type = models.ForeignKey(
         PaymentType,
-        on_delete = models.CASCADE,
         null = True,
         blank = True
     )

--- a/website/templates/user_payment_options.html
+++ b/website/templates/user_payment_options.html
@@ -1,0 +1,18 @@
+{% extends "index.html" %}
+{% block content %}
+    <h1>My Payments</h1>
+
+    <form action="{% url 'website:user_payment_options' %}" method="post">
+    {% csrf_token %}
+        <select name="payment_list">
+        {% for payment_type in all_payment_types %}
+            <option id="{{payment_type.id}}" name="{{payment_type.id}}" value="{{payment_type.id}}">{{ payment_type.name }} - {{payment_type.account_number}}</option>
+        {% endfor %}
+        </select>
+        {% if not all_payment_types %}
+            <a href="{% url 'website:add_payment_type' %}">Add Payment</a>
+        {% else %}
+            <input type="submit" value="Complete Order"/>
+    </form>
+    {% endif %}
+{% endblock %}

--- a/website/templates/user_payment_options.html
+++ b/website/templates/user_payment_options.html
@@ -2,17 +2,21 @@
 {% block content %}
     <h1>My Payments</h1>
 
-    <form action="{% url 'website:user_payment_options' %}" method="post">
-    {% csrf_token %}
+      {% for payment_type in all_payment_types %}
       <ul>
-        {% for payment_type in all_payment_types %}
-            <li id="{{payment_type.id}}" name="{{payment_type.id}}" value="{{payment_type.id}}">{{ payment_type.name }} - {{payment_type.account_number}}</li>
-        {% endfor %}
+          <li id="{{payment_type.id}}" name="{{payment_type.id}}" value="{{payment_type.id}}">{{payment_type.name}} - {{payment_type.account_number}}
+          <form action="{% url 'website:user_payment_options' %}" method="post">
+          {% csrf_token %}
+              <input name="delete_payment" type="hidden" value="{{payment_type.id}}"/>
+              <input class="btn btn-warning btn-xl" type="submit" value="Delete Payment"/>
+          </form>
+          </li>
+
       </ul>
+      {% endfor %}
 
-        {% if not all_payment_types %}
-            <a href="{% url 'website:add_payment_type' %}">Add Payment</a>
+      {% if not all_payment_types %}
+          <a href="{% url 'website:add_payment_type' %}">Add Payment</a>
 
-    </form>
-        {% endif %}
+      {% endif %}
 {% endblock %}

--- a/website/templates/user_payment_options.html
+++ b/website/templates/user_payment_options.html
@@ -4,15 +4,15 @@
 
     <form action="{% url 'website:user_payment_options' %}" method="post">
     {% csrf_token %}
-        <select name="payment_list">
+      <ul>
         {% for payment_type in all_payment_types %}
-            <option id="{{payment_type.id}}" name="{{payment_type.id}}" value="{{payment_type.id}}">{{ payment_type.name }} - {{payment_type.account_number}}</option>
+            <li id="{{payment_type.id}}" name="{{payment_type.id}}" value="{{payment_type.id}}">{{ payment_type.name }} - {{payment_type.account_number}}</li>
         {% endfor %}
-        </select>
+      </ul>
+
         {% if not all_payment_types %}
             <a href="{% url 'website:add_payment_type' %}">Add Payment</a>
-        {% else %}
-            <input type="submit" value="Complete Order"/>
+
     </form>
-    {% endif %}
+        {% endif %}
 {% endblock %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -6,7 +6,7 @@ from website.views.single_category import *
 from website.views.shopping_cart_view import *
 from website.views.complete_order import *
 from website.views.product_search_view import product_search
-from website.views.list_payments import delete_payment
+from website.views.user_payment_options_view import delete_payment
 
 
 app_name = "website"

--- a/website/urls.py
+++ b/website/urls.py
@@ -6,6 +6,8 @@ from website.views.single_category import *
 from website.views.shopping_cart_view import *
 from website.views.complete_order import *
 from website.views.product_search_view import product_search
+from website.views.list_payments import delete_payment
+
 
 app_name = "website"
 urlpatterns = [
@@ -24,5 +26,6 @@ urlpatterns = [
     url(r'^single_category/(?P<category_id>.+?)/$', single_category, name='single_category'),
     url(r'^shopping_cart$', shopping_cart, name='shopping_cart'),
     url(r'^product_search$', product_search, name='product_search'),
+    url(r'^user_payment_options$', delete_payment, name='user_payment_options'),
 
 ]

--- a/website/views/complete_order.py
+++ b/website/views/complete_order.py
@@ -18,7 +18,7 @@ def complete_order(request):
     """
     if request.method == "GET":
         user = request.user
-        all_payment_types = PaymentType.objects.filter(user_id=user.id)
+        all_payment_types = PaymentType.objects.filter(user_id=user.id, enabled=1)
         template_name = 'complete_order.html'
         payment_type_dict = {'all_payment_types': all_payment_types}
         return render(request, template_name, payment_type_dict)

--- a/website/views/shopping_cart_view.py
+++ b/website/views/shopping_cart_view.py
@@ -18,7 +18,7 @@ def shopping_cart(request):
     the request with that rendered text.
     """
     if request.method == "GET":
-        user_order = Order.objects.get_or_create(payment_type_id = None, user_id = request.user)
+        user_order = Order.objects.get_or_create(payment_type_id = None, user_id = request.user.id)
         template_name = 'shopping_cart.html'
 
         products_on_order = LineItem.objects.all().filter(order_id = user_order[0].id)

--- a/website/views/user_payment_options_view.py
+++ b/website/views/user_payment_options_view.py
@@ -1,13 +1,15 @@
+from django.shortcuts import get_object_or_404, render
+
 from website.forms import UserForm
 from website.models import PaymentType, Order
 
 
 
-def delete_payment():
+def delete_payment(request):
 
 	if request.method == "GET":
 		user = request.user
 		all_payment_types = PaymentType.objects.filter(user_id=user.id)
-		template_name = 'complete_order.html'
+		template_name = 'user_payment_options.html'
 		payment_type_dict = {'all_payment_types': all_payment_types}
 		return render(request, template_name, payment_type_dict)

--- a/website/views/user_payment_options_view.py
+++ b/website/views/user_payment_options_view.py
@@ -1,9 +1,13 @@
-import 
+from website.forms import UserForm
+from website.models import PaymentType, Order
+
+
+
 def delete_payment():
 
 	if request.method == "GET":
-        user = request.user
-        all_payment_types = PaymentType.objects.filter(user_id=user.id)
-        template_name = 'complete_order.html'
-        payment_type_dict = {'all_payment_types': all_payment_types}
-        return render(request, template_name, payment_type_dict)
+		user = request.user
+		all_payment_types = PaymentType.objects.filter(user_id=user.id)
+		template_name = 'complete_order.html'
+		payment_type_dict = {'all_payment_types': all_payment_types}
+		return render(request, template_name, payment_type_dict)

--- a/website/views/user_payment_options_view.py
+++ b/website/views/user_payment_options_view.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404, render
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 
 from website.forms import UserForm
 from website.models import PaymentType, Order
@@ -9,7 +10,27 @@ def delete_payment(request):
 
 	if request.method == "GET":
 		user = request.user
-		all_payment_types = PaymentType.objects.filter(user_id=user.id)
+		all_payment_types = PaymentType.objects.filter(user_id=user.id, enabled=1)
 		template_name = 'user_payment_options.html'
 		payment_type_dict = {'all_payment_types': all_payment_types}
 		return render(request, template_name, payment_type_dict)
+
+	elif request.method == 'POST':
+		payment_id = request.POST['delete_payment']
+		print('---------------------------')
+		print(payment_id)
+		print('---------------------------')
+		payment_is_on_order = Order.objects.filter(
+			user_id=request.user,
+			payment_type=payment_id
+		)
+
+		if not payment_is_on_order:
+			PaymentType.objects.filter(pk=payment_id).delete()
+			return HttpResponseRedirect('/user_payment_options')
+
+		else:
+			payment_is_used = PaymentType.objects.get(pk=payment_id)
+			payment_is_used.enabled = 0
+			payment_is_used.save()
+			return HttpResponseRedirect('/user_payment_options')

--- a/website/views/user_payment_options_view.py
+++ b/website/views/user_payment_options_view.py
@@ -1,0 +1,9 @@
+import 
+def delete_payment():
+
+	if request.method == "GET":
+        user = request.user
+        all_payment_types = PaymentType.objects.filter(user_id=user.id)
+        template_name = 'complete_order.html'
+        payment_type_dict = {'all_payment_types': all_payment_types}
+        return render(request, template_name, payment_type_dict)

--- a/website/views/views.py
+++ b/website/views/views.py
@@ -166,4 +166,4 @@ def add_payment_type(request):
             account_number=form_data['account_number'],
         )
         p.save()
-        return HttpResponseRedirect('/categories')
+        return HttpResponseRedirect('/user_payment_options')


### PR DESCRIPTION
## 1. TITLE:
Added functionality to delete and disable payment types.

## 2. STATUS:
Ready

## 3. DESCRIPTION:
***Rationale(reason behind updated changes)***
Give users ability to delete or disable their payment types
To test:
run damnit django there are new model changes,
create a few payment types,
delete a payment type,
ensure in db that it is gone,
checkout an order with one payment type,
now delete that payment type,
make sure it's no longer displaying,
make sure it is still in database and enabled field is set to 0.


## 4. RELATED TICKETS:
[8](https://github.com/EducatedCamels/djangazon/issues/8)


## 5. FILES CHANGED:
```
modified:   website/models.py
modified:   website/templates/user_payment_options.html
modified:   website/views/complete_order.py
modified:   website/views/shopping_cart_view.py
modified:   website/views/user_payment_options_view.py
```

## 6. STEPS TO RUN PROJECT:

```./damnit_django.sh```
```python manage.py runserver```

    
## 8. TESTING THE CODE:

No new unit tests



### For reference: [Bangazon Employee Handbook: Pull Requests](https://github.com/nashville-software-school/bangazon-llc/blob/master/EMPLOYEE_HANDBOOK.md)
