### PR TITLE
Added to search_product function

### DIFF
--- a/website/fixtures/product.json
+++ b/website/fixtures/product.json
@@ -19,7 +19,7 @@
       "price": 375.00,
       "description": "This is a good amp! You should buy it.",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "New York",
       "date": "2017-05-22",
       "category": 1,
       "seller": 2
@@ -32,7 +32,7 @@
       "price": 2000.00,
       "description": "This mac books works well.",
       "quantity": 5,
-      "city": "Nashville",
+      "city": "New York",
       "date": "2017-05-22",
       "category": 1,
       "seller": 1
@@ -45,7 +45,7 @@
       "price": 150.00,
       "description": "It plays blue ray.",
       "quantity": 2,
-      "city": "Nashville",
+      "city": "Tuscaloosa",
       "date": "2017-05-22",
       "category": 1,
       "seller": 2
@@ -58,7 +58,7 @@
       "price": 19.00,
       "description": "You can write things on it.",
       "quantity": 7,
-      "city": "Nashville",
+      "city": "Pincher Creek",
       "date": "2017-05-22",
       "category": 8,
       "seller": 3
@@ -71,7 +71,7 @@
       "price": 30.00,
       "description": "",
       "quantity": 3000,
-      "city": "Nashville",
+      "city": "Tuscaloosa",
       "date": "2017-05-22",
       "category": 8,
       "seller": 4
@@ -97,7 +97,7 @@
       "price": 112.00,
       "description": "Quality battery.",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "Chattanooga",
       "date": "2017-05-22",
       "category": 2,
       "seller": 6
@@ -110,7 +110,7 @@
       "price": 10.00,
       "description": "Holds all your coffee mugs and stuff.",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "Chattanooga",
       "date": "2017-05-22",
       "category": 2,
       "seller": 1
@@ -149,7 +149,7 @@
       "price": 100200.00,
       "description": "Nicest ring ever!!",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "Boston",
       "date": "2017-05-22",
       "category": 3,
       "seller": 7
@@ -162,7 +162,7 @@
       "price": 45.00,
       "description": "I have no idea why people play this.",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "Boston",
       "date": "2017-05-22",
       "category": 4,
       "seller": 6
@@ -175,7 +175,7 @@
       "price": 17.00,
       "description": "This a ball. It is Red",
       "quantity": 3,
-      "city": "Nashville",
+      "city": "Pincher Creek",
       "date": "2017-05-22",
       "category": 4,
       "seller": 6

--- a/website/models.py
+++ b/website/models.py
@@ -52,7 +52,7 @@ class Product(models.Model):
     category = models.ForeignKey(
         Category,
         on_delete = models.CASCADE,
-        related_name = 'product'
+        related_name = 'products'
     )
     seller = models.ForeignKey(
         User,

--- a/website/views/product_search_view.py
+++ b/website/views/product_search_view.py
@@ -7,11 +7,11 @@ from website.models import Product
 
 def product_search(request):
 
-    all_products = Product.objects.all().order_by("title")
+    all_products = Product.objects.all().order_by("title", "city")
     query = request.GET.get("q")
     template_name = 'product/product_search.html'
     if query:
         products = all_products.filter(
-        Q(title__contains=query)
+        Q(title__contains=query) | Q(city__contains=query)
         ).distinct()
         return render(request, template_name, {'all_products': products})

--- a/website/views/product_search_view.py
+++ b/website/views/product_search_view.py
@@ -7,11 +7,11 @@ from website.models import Product
 
 def product_search(request):
 
-    all_products = Product.objects.all().order_by("title", "city")
+    all_products = Product.objects.all().order_by("title", "city", "category")
     query = request.GET.get("q")
     template_name = 'product/product_search.html'
-    if query:
+    if query:	
         products = all_products.filter(
-        Q(title__contains=query) | Q(city__contains=query)
+        Q(title__contains=query) | Q(city__contains=query) | Q(category__name__contains=query)
         ).distinct()
         return render(request, template_name, {'all_products': products})


### PR DESCRIPTION
## 1. TITLE:
Created ability to search products by city

## 2. STATUS:
Ready. But trying to add ability to search category as an extra feature. 

## 3. DESCRIPTION:
***Rationale(reason behind updated changes)***
A feature ticket required products to be searched by city so this code allows that to happen. Had to change fixtures as well.
***Expected behavior of changes***
Should now be able to type a city in the search bar and get any product that is in that city.

## 4. RELATED TICKETS:
#5 


## 5. FILES CHANGED:
fixtures/product.json
product_search_view.py
models.py

## 6. STEPS TO RUN PROJECT:
#### ***Run steps***
`./damnit_django.sh`
`python manage.py runserver` 
Register and type a city that you know is in the fixtures in the search bar (like Nashville, New York, Pincher Creek or Boston) and see if the products come up. 


### For reference: [Bangazon Employee Handbook: Pull Requests](https://github.com/nashville-software-school/bangazon-llc/blob/master/EMPLOYEE_HANDBOOK.md)
